### PR TITLE
Update dalle_back.ipynb

### DIFF
--- a/dalle_back.ipynb
+++ b/dalle_back.ipynb
@@ -57,7 +57,7 @@
         "!npm install -g localtunnel\n",
         "clear_output()\n",
         "%cd /content/\n",
-        "!pip install Flask==1.1.2 Flask-Cors==3.0.9 Flask-RESTful==0.3.8 dalle-pytorch tqdm\n",
+        "!pip install Flask==1.1.2 Flask-Cors==3.0.9 Flask-RESTful==0.3.8 dalle-pytorch==0.13.0 tqdm\n",
         "!git clone https://github.com/rom1504/dalle-service.git\n",
         "clear_output()\n",
         "print(\"Finished setup.\")"


### PR DESCRIPTION
It seems that the latest dalle-pytorch has changed the model structure. And version 0.13.0 is perfectly compatible with the default pre-training model.